### PR TITLE
Update list of active AI newsletters

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,16 @@ Some links on this page are referral/affiliate links. If you click a link and su
 
 Perfect for staying updated on AI trends, news, and developments across all areas.
 
-- ⭐ (Sponsored) [The Neuron](http://recommendations.page/heynews?ref_code=580a42ceb3) - Essential AI trend updates to keep you in the know (550K+ subscribers)
-- ⭐ (Sponsored) [The Rundown AI](https://sparklp.co/p/6080ca220f) - Get the latest AI news, understand why it matters, and learn how to apply it in your work (1M+ subscribers)
-- ⭐ (Sponsored) [Horizon AI](https://www.joinhorizon.ai/?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily 3-minute briefings on everything you need to know about AI and tech (100K+ subscribers)
-- [Superhuman AI](https://www.superhuman.ai/subscribe?utm_source=github.com/csarigoz/best-ai-newsletters) - Boost your productivity and career with AI insights (1M+ subscribers)
+- ⭐ (Sponsored) [The Neuron](http://recommendations.page/heynews?ref_code=580a42ceb3) - Essential AI trend updates to keep you in the know
+- ⭐ (Sponsored) [The Rundown AI](https://sparklp.co/p/6080ca220f) - Get the latest AI news, understand why it matters, and learn how to apply it in your work
+- ⭐ (Sponsored) [Horizon AI](https://www.joinhorizon.ai/?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily 3-minute briefings on everything you need to know about AI and tech
+- [Superhuman AI](https://www.superhuman.ai/subscribe?utm_source=github.com/csarigoz/best-ai-newsletters) - Boost your productivity and career with AI insights
 - [TLDR AI](https://tldr.tech/ai?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily digest of AI, machine learning, and data science news
-- [Ben's Bites](https://www.bensbites.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily AI updates in fun, casual, and easy-to-digest format (100K+ subscribers)
-- [Mindstream](https://mindstream.news?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily hot takes, expert opinions, and interactive polls (150K+ subscribers, HubSpot Media Network)
-- [AI Breakfast](https://aibreakfast.beehiiv.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Weekly deep dives into cutting-edge AI projects and trends (3x per week, 95K+ subscribers)
-- [AI Ready (fka Not A Bot)](https://www.aiready.so/?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily AI news, written by humans (50K+ subscribers)
-- [AI Valley](https://www.theaivalley.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily comprehensive AI updates with tools and tutorials (80K+ subscribers)
+- [Ben's Bites](https://www.bensbites.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily AI updates in fun, casual, and easy-to-digest format
+- [Mindstream](https://mindstream.news?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily hot takes, expert opinions, and interactive polls (in HubSpot Media Network)
+- [AI Breakfast](https://aibreakfast.beehiiv.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Weekly deep dives into cutting-edge AI projects and trends (3x per week)
+- [AI Ready (fka Not A Bot)](https://www.aiready.so/?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily AI news, written by humans
+- [AI Valley](https://www.theaivalley.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily comprehensive AI updates with tools and tutorials
 
 <a name="technical"></a>
 ## 🧠 Technical & Developer Focused
@@ -53,9 +53,9 @@ Perfect for staying updated on AI trends, news, and developments across all area
 For AI engineers, researchers, and technical professionals who want in-depth technical insights.
 
 - [The Batch](https://www.deeplearning.ai/the-batch/?utm_source=github.com/csarigoz/best-ai-newsletters) - Weekly authoritative coverage from Andrew Ng's DeepLearning.AI
-- [Import AI](https://importai.substack.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Weekly analysis and updates on AI policy and research (70K+ subscribers)
-- [The ML Engineer Newsletter](https://ethical.institute/mle.html?utm_source=github.com/csarigoz/best-ai-newsletters) - Expert insights on machine learning best practices (70K+ ML professionals)
-- [AlphaSignal](https://alphasignal.ai/?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily digest for engineers with coding tips and trending repos (200K+ developers)
+- [Import AI](https://importai.substack.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Weekly analysis and updates on AI policy and research
+- [The ML Engineer Newsletter](https://ethical.institute/mle.html?utm_source=github.com/csarigoz/best-ai-newsletters) - Expert insights on machine learning best practices
+- [AlphaSignal](https://alphasignal.ai/?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily digest for engineers with coding tips and trending repos
 - [The Sequence](https://thesequence.substack.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Weekly no-BS approach to AI with practical applications
 - [Latent Space](https://latent.space/?utm_source=github.com/csarigoz/best-ai-newsletters) - Technical insights for AI engineers on model training and infrastructure (Top 10 US Tech podcast)
 
@@ -66,7 +66,7 @@ AI insights specifically tailored for business leaders, executives, and enterpri
 
 - [Enterprise AI Solutions](https://www.enterpriseaisolutions.io?utm_source=github.com/csarigoz/best-ai-newsletters) - No-fluff AI insights for 10,000+ enterprise leaders (actionable strategies and real-world use cases)
 - [AI Adopters Club](https://aiadopters.club/?utm_source=github.com/csarigoz/best-ai-newsletters) - Practical look at how businesses use AI with case studies
-- [Ahead of AI](https://magazine.sebastianraschka.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Research trends and practical developments by Sebastian Raschka, PhD (tens of thousands of subscribers)
+- [Ahead of AI](https://magazine.sebastianraschka.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Research trends and practical developments by Sebastian Raschka, PhD
 - [AI News](https://artificialintelligence-news.com/newsletter/?utm_source=github.com/csarigoz/best-ai-newsletters) - Newsletter written partly with AI, covering industry trends
 - [The AI Optimist](https://www.theaioptimist.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Strategic AI briefings for business decision makers (weekly, action-focused)
 
@@ -75,8 +75,8 @@ AI insights specifically tailored for business leaders, executives, and enterpri
 
 Discover and learn about the latest AI tools, platforms, and software.
 
-- [There's An AI For That](https://newsletter.theresanaiforthat.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily newsletter on AI news and tools (2.1M+ readers, 3x per week)
-- [FutureTools](https://futuretools.beehiiv.com/subscribe?utm_source=github.com/csarigoz/best-ai-newsletters) - Comprehensive roundup of AI tools, news, and monetization strategies (170K+ subscribers)
+- [There's An AI For That](https://newsletter.theresanaiforthat.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily newsletter on AI news and tools (3x per week)
+- [FutureTools](https://futuretools.beehiiv.com/subscribe?utm_source=github.com/csarigoz/best-ai-newsletters) - Comprehensive roundup of AI tools, news, and monetization strategies
 - [AI Tool Report](https://aitoolreport.beehiiv.com/subscribe?utm_source=github.com/csarigoz/best-ai-newsletters) - Learn to save time and earn more with AI (5-minute daily updates)
 - [AI Break](https://theaibreak.substack.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - AI tools integration into business processes
 
@@ -130,7 +130,7 @@ AI newsletters focused on specific industries like healthcare, finance, and more
 For researchers, academics, and those interested in cutting-edge AI research.
 
 - [The Algorithmic Bridge](https://thealgorithmicbridge.substack.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - AI from human-centric perspective with ethical contexts
-- [Last Week in AI](https://lastweekin.ai/?utm_source=github.com/csarigoz/best-ai-newsletters) - Weekly concise updates on AI research and developments (hundreds of thousands of subscribers)
+- [Last Week in AI](https://lastweekin.ai/?utm_source=github.com/csarigoz/best-ai-newsletters) - Weekly concise updates on AI research and developments
 - [Stanford HAI Newsletter](https://hai.stanford.edu/news?utm_source=github.com/csarigoz/best-ai-newsletters) - Weekly research, policy, and education updates from Stanford
 - [The Gradient (Stanford)](https://thegradientpub.substack.com/s/the-update?utm_source=github.com/csarigoz/best-ai-newsletters) - Academic AI research with democratizing knowledge focus
 - [Edge AI and Vision Insights](https://www.edge-ai-vision.com/latest-news/newsletter/?utm_source=github.com/csarigoz/best-ai-newsletters) - Computer vision, edge AI, and embedded vision
@@ -143,7 +143,7 @@ AI newsletters for creators, writers, and content professionals.
 
 - [Write with AI](https://writewithai.substack.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Teaching writers how to use AI for content creation
 - [Visually AI](https://heatherbcooper.substack.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Generative AI-focused content covering tools, prompts, and news (weekly)
-- [AI Art Weekly](https://aiartweekly.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - AI art news, interviews, and creative resources (3,550+ subscribers)
+- [AI Art Weekly](https://aiartweekly.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - AI art news, interviews, and creative resources
 
 <a name="safety-ethics"></a>
 ## 🛡 AI Safety & Ethics

--- a/README.md
+++ b/README.md
@@ -36,16 +36,16 @@ Some links on this page are referral/affiliate links. If you click a link and su
 
 Perfect for staying updated on AI trends, news, and developments across all areas.
 
-- ⭐ (Sponsored) [The Neuron](http://recommendations.page/heynews?ref_code=580a42ceb3) - Essential AI trend updates to keep you in the know
-- ⭐ (Sponsored) [The Rundown AI](https://sparklp.co/p/6080ca220f) - Get the latest AI news, understand why it matters, and learn how to apply it in your work
-- ⭐ (Sponsored) [Horizon AI](https://www.joinhorizon.ai/?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily 3-minute briefings on everything you need to know about AI and tech
-- [Superhuman AI](https://www.superhuman.ai/subscribe?utm_source=github.com/csarigoz/best-ai-newsletters) - Boost your productivity and career with AI insights
+- ⭐ (Sponsored) [The Neuron](http://recommendations.page/heynews?ref_code=580a42ceb3) - Essential AI trend updates to keep you in the know (550K+ subscribers)
+- ⭐ (Sponsored) [The Rundown AI](https://sparklp.co/p/6080ca220f) - Get the latest AI news, understand why it matters, and learn how to apply it in your work (1M+ subscribers)
+- ⭐ (Sponsored) [Horizon AI](https://www.joinhorizon.ai/?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily 3-minute briefings on everything you need to know about AI and tech (100K+ subscribers)
+- [Superhuman AI](https://www.superhuman.ai/subscribe?utm_source=github.com/csarigoz/best-ai-newsletters) - Boost your productivity and career with AI insights (1M+ subscribers)
 - [TLDR AI](https://tldr.tech/ai?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily digest of AI, machine learning, and data science news
-- [Ben's Bites](https://www.bensbites.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily AI updates in fun, casual, and easy-to-digest format
-- [Mindstream](https://mindstream.news?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily hot takes, expert opinions, and interactive polls
-- [AI Breakfast](https://aibreakfast.beehiiv.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Weekly deep dives into cutting-edge AI projects and trends (3x per week, 54K+ subscribers)
-- [AI Ready (fka Not A Bot)](https://www.aiready.so/?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily AI news, written by humans
-- [AI Valley](https://www.theaivalley.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily comprehensive AI updates with tools and tutorials
+- [Ben's Bites](https://www.bensbites.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily AI updates in fun, casual, and easy-to-digest format (100K+ subscribers)
+- [Mindstream](https://mindstream.news?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily hot takes, expert opinions, and interactive polls (150K+ subscribers, HubSpot Media Network)
+- [AI Breakfast](https://aibreakfast.beehiiv.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Weekly deep dives into cutting-edge AI projects and trends (3x per week, 95K+ subscribers)
+- [AI Ready (fka Not A Bot)](https://www.aiready.so/?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily AI news, written by humans (50K+ subscribers)
+- [AI Valley](https://www.theaivalley.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily comprehensive AI updates with tools and tutorials (80K+ subscribers)
 
 <a name="technical"></a>
 ## 🧠 Technical & Developer Focused
@@ -53,31 +53,31 @@ Perfect for staying updated on AI trends, news, and developments across all area
 For AI engineers, researchers, and technical professionals who want in-depth technical insights.
 
 - [The Batch](https://www.deeplearning.ai/the-batch/?utm_source=github.com/csarigoz/best-ai-newsletters) - Weekly authoritative coverage from Andrew Ng's DeepLearning.AI
-- [Import AI](https://importai.substack.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Weekly analysis and updates on AI policy and research
-- [The ML Engineer Newsletter](https://ethical.institute/mle.html?utm_source=github.com/csarigoz/best-ai-newsletters) - Expert insights on machine learning best practices
-- [AlphaSignal](https://alphasignal.ai/?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily digest for engineers with coding tips and trending repos
+- [Import AI](https://importai.substack.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Weekly analysis and updates on AI policy and research (70K+ subscribers)
+- [The ML Engineer Newsletter](https://ethical.institute/mle.html?utm_source=github.com/csarigoz/best-ai-newsletters) - Expert insights on machine learning best practices (70K+ ML professionals)
+- [AlphaSignal](https://alphasignal.ai/?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily digest for engineers with coding tips and trending repos (200K+ developers)
 - [The Sequence](https://thesequence.substack.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Weekly no-BS approach to AI with practical applications
-- [Latent Space](https://latent.space/?utm_source=github.com/csarigoz/best-ai-newsletters) - Technical insights for AI engineers on model training and infrastructure
+- [Latent Space](https://latent.space/?utm_source=github.com/csarigoz/best-ai-newsletters) - Technical insights for AI engineers on model training and infrastructure (Top 10 US Tech podcast)
 
 <a name="business-enterprise"></a>
 ## 🏢 Business & Enterprise
 
 AI insights specifically tailored for business leaders, executives, and enterprise decision-makers.
 
-- [Enterprise AI Solutions](https://www.enterpriseaisolutions.io?utm_source=github.com/csarigoz/best-ai-newsletters) - No-fluff AI insights for 10,000+ enterprise leaders
+- [Enterprise AI Solutions](https://www.enterpriseaisolutions.io?utm_source=github.com/csarigoz/best-ai-newsletters) - No-fluff AI insights for 10,000+ enterprise leaders (actionable strategies and real-world use cases)
 - [AI Adopters Club](https://aiadopters.club/?utm_source=github.com/csarigoz/best-ai-newsletters) - Practical look at how businesses use AI with case studies
-- [Ahead of AI](https://magazine.sebastianraschka.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Research trends and practical developments for business audience
+- [Ahead of AI](https://magazine.sebastianraschka.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Research trends and practical developments by Sebastian Raschka, PhD (tens of thousands of subscribers)
 - [AI News](https://artificialintelligence-news.com/newsletter/?utm_source=github.com/csarigoz/best-ai-newsletters) - Newsletter written partly with AI, covering industry trends
-- [The AI Optimist](https://www.theaioptimist.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Strategic AI briefings for business decision makers
+- [The AI Optimist](https://www.theaioptimist.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Strategic AI briefings for business decision makers (weekly, action-focused)
 
 <a name="ai-tools"></a>
 ## 🧰 AI Tools & Platforms
 
 Discover and learn about the latest AI tools, platforms, and software.
 
-- [There's An AI For That](https://newsletter.theresanaiforthat.com/) - Daily newsletter on AI news and tools
-- [FutureTools](https://futuretools.beehiiv.com/subscribe?utm_source=github.com/csarigoz/best-ai-newsletters) - Comprehensive roundup of AI tools, news, and monetization strategies
-- [AI Tool Report](https://aitoolreport.beehiiv.com/subscribe?utm_source=github.com/csarigoz/best-ai-newsletters) - Learn to save time and earn more with AI
+- [There's An AI For That](https://newsletter.theresanaiforthat.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily newsletter on AI news and tools (2.1M+ readers, 3x per week)
+- [FutureTools](https://futuretools.beehiiv.com/subscribe?utm_source=github.com/csarigoz/best-ai-newsletters) - Comprehensive roundup of AI tools, news, and monetization strategies (170K+ subscribers)
+- [AI Tool Report](https://aitoolreport.beehiiv.com/subscribe?utm_source=github.com/csarigoz/best-ai-newsletters) - Learn to save time and earn more with AI (5-minute daily updates)
 - [AI Break](https://theaibreak.substack.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - AI tools integration into business processes
 
 <a name="prompts"></a>
@@ -85,8 +85,7 @@ Discover and learn about the latest AI tools, platforms, and software.
 
 Master the art of prompt engineering and get the most out of AI models.
 
-- [Prompts Daily](https://www.neatprompts.com/subscribe?utm_source=github.com/csarigoz/best-ai-newsletters) - Discover AI-powered marketing and productivity hacks
-- [Prompt Engineering Daily](https://promptengineeringdaily.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily insights into prompt engineering and AI integration
+- [Prompts Daily](https://www.neatprompts.com/subscribe?utm_source=github.com/csarigoz/best-ai-newsletters) - Discover AI-powered marketing and productivity hacks (100K+ readers)
 
 <a name="sales-marketing"></a>
 ## 🚀 Sales & Marketing
@@ -131,11 +130,11 @@ AI newsletters focused on specific industries like healthcare, finance, and more
 For researchers, academics, and those interested in cutting-edge AI research.
 
 - [The Algorithmic Bridge](https://thealgorithmicbridge.substack.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - AI from human-centric perspective with ethical contexts
-- [Last Week in AI](https://lastweekin.ai/?utm_source=github.com/csarigoz/best-ai-newsletters) - Weekly concise updates on AI research and developments
-- [Stanford HAI Newsletter](https://hai.stanford.edu/news?utm_source=github.com/csarigoz/best-ai-newsletters) - Weekly research, policy, and education updates
+- [Last Week in AI](https://lastweekin.ai/?utm_source=github.com/csarigoz/best-ai-newsletters) - Weekly concise updates on AI research and developments (hundreds of thousands of subscribers)
+- [Stanford HAI Newsletter](https://hai.stanford.edu/news?utm_source=github.com/csarigoz/best-ai-newsletters) - Weekly research, policy, and education updates from Stanford
 - [The Gradient (Stanford)](https://thegradientpub.substack.com/s/the-update?utm_source=github.com/csarigoz/best-ai-newsletters) - Academic AI research with democratizing knowledge focus
 - [Edge AI and Vision Insights](https://www.edge-ai-vision.com/latest-news/newsletter/?utm_source=github.com/csarigoz/best-ai-newsletters) - Computer vision, edge AI, and embedded vision
-- [The Variable (Towards Data Science)](https://towardsdatascience.com/) - Data science and ML research with practical applications
+- [The Variable (Towards Data Science)](https://towardsdatascience.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Data science and ML research with practical applications
 
 <a name="creative-content"></a>
 ## 🎨 Creative & Content
@@ -143,8 +142,8 @@ For researchers, academics, and those interested in cutting-edge AI research.
 AI newsletters for creators, writers, and content professionals.
 
 - [Write with AI](https://writewithai.substack.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Teaching writers how to use AI for content creation
-- [Visually AI](https://heatherbcooper.substack.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Generative AI-focused content covering tools, prompts, and news
-- [AI Art Weekly](https://aiartweekly.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - AI art news, interviews, and creative resources
+- [Visually AI](https://heatherbcooper.substack.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Generative AI-focused content covering tools, prompts, and news (weekly)
+- [AI Art Weekly](https://aiartweekly.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - AI art news, interviews, and creative resources (3,550+ subscribers)
 
 <a name="safety-ethics"></a>
 ## 🛡 AI Safety & Ethics
@@ -183,7 +182,7 @@ Newsletters from major AI platforms and companies.
 <a name="curation-policy"></a>
 ## 🧹 Curation Policy
 
-Only active newsletters are listed here. A newsletter is considered active if it has published at least one issue in the last 30 days. Inactive newsletters are periodically removed to keep this list fresh and useful. This list was last updated in September 2025 and includes 44 active AI newsletters across 11 categories.
+Only active newsletters are listed here. A newsletter is considered active if it has published at least one issue in the last 15 days. Inactive newsletters are periodically removed to keep this list fresh and useful. This list was last updated in November 2025 and includes verified active AI newsletters across 11 categories.
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates README newsletter entries with refined descriptions/links across categories and tightens curation policy to 15-day activity (last updated Nov 2025).
> 
> - **README updates**:
>   - **General**: Tweaks to `Mindstream` and `AI Breakfast` descriptions; minor clarifications on listings.
>   - **Technical**: Adds accolade to `Latent Space` entry.
>   - **Business & Enterprise**: Expands descriptions for `Enterprise AI Solutions`, `Ahead of AI`, and `The AI Optimist`.
>   - **AI Tools & Platforms**: Updates links/descriptions for `There's An AI For That` and `AI Tool Report`.
>   - **Prompts**: Adds readership note to `Prompts Daily`.
>   - **Research & Academic**: Clarifies `Stanford HAI Newsletter` and updates `The Variable` link; minor wording tweaks.
>   - **Creative & Content**: Notes cadence for `Visually AI`.
>   - **Curation Policy**: Changes activity window from `30` to `15` days and updates timestamp to November 2025; clarifies that only verified active newsletters are listed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a574ed5454c690e19e8a37810c5ec3ea243798aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->