### PR TITLE
Add AI Weekly to newsletter/resource list

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Some links on this page are referral/affiliate links. If you click a link and su
 <a name="general"></a>
 ## 🌟 General AI Newsletters
 
+- [AI Weekly](https://aiweekly.co/?utm_source=github.com/csarigoz/best-ai-newsletters) - The few AI news stories that matter, curated by an independent editor since 2015 (3x per week, for 44,000+ professionals)
 Perfect for staying updated on AI trends, news, and developments across all areas.
 
 - ⭐ (Sponsored) [The Neuron](http://recommendations.page/heynews?ref_code=580a42ceb3) - Essential AI trend updates to keep you in the know


### PR DESCRIPTION
Adding [AI Weekly](https://aiweekly.co) — curated AI intelligence briefing from industry leaders. 3x/week since 2017, 40K+ subscribers. Covers models, funding, policy, and real-world applications.