### PR TITLE
Add Creative AI News to Creative & Content section

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ AI newsletters for creators, writers, and content professionals.
 - [Write with AI](https://writewithai.substack.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Teaching writers how to use AI for content creation
 - [Visually AI](https://heatherbcooper.substack.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Generative AI-focused content covering tools, prompts, and news (weekly)
 - [AI Art Weekly](https://aiartweekly.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - AI art news, interviews, and creative resources
+- [Creative AI News](https://www.creativeainews.com?utm_source=github.com/csarigoz/best-ai-newsletters) - Weekly AI tools and workflows for every working creator: image, video, audio, 3D, and code.
 
 <a name="safety-ethics"></a>
 ## 🛡 AI Safety & Ethics


### PR DESCRIPTION
Adding [Creative AI News](https://www.creativeainews.com), a weekly newsletter covering AI tools and workflows for working creators across image, video, audio, 3D, and code.

Quick context:
- 411 published articles, weekly cadence
- Pillar guides covering AI Video, AI Image, ComfyUI, AI Coding, AI Music, and Open-Source AI
- Editorial focus on what ships for creators, not benchmark sheets

Added one entry to the 🎨 Creative & Content section, matching the existing format (including the utm_source attribution).