### PR TITLE
Add DiamantAI to Technical & Developer Focused

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ For AI engineers, researchers, and technical professionals who want in-depth tec
 - [AlphaSignal](https://alphasignal.ai/?utm_source=github.com/csarigoz/best-ai-newsletters) - Daily digest for engineers with coding tips and trending repos
 - [The Sequence](https://thesequence.substack.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Weekly no-BS approach to AI with practical applications
 - [Latent Space](https://latent.space/?utm_source=github.com/csarigoz/best-ai-newsletters) - Technical insights for AI engineers on model training and infrastructure (Top 10 US Tech podcast)
+- [DiamantAI](https://diamantai.substack.com/?utm_source=github.com/csarigoz/best-ai-newsletters) - Practical AI engineering and generative AI for builders: RAG, agents, and LLM application patterns explained simply
 
 <a name="business-enterprise"></a>
 ## 🏢 Business & Enterprise


### PR DESCRIPTION
Adding DiamantAI to the Technical & Developer Focused section.

[DiamantAI](https://diamantai.substack.com) covers practical AI engineering and generative AI (RAG, agents, LLM application patterns) for builders. Matched the section's utm_source link format.

Per the FTC disclosure norm of this list: I am the author of this newsletter.